### PR TITLE
Signon integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,10 @@ gem 'flowdock'
 # GitHub OAuth
 gem 'omniauth-github'
 
+# GDS Signon
+gem 'omniauth-gds', '3.0.0'
+gem 'plek', '1.7.0'
+
 gem 'ri_cal'
 gem 'yajl-ruby', :require => "yajl"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,8 @@ GEM
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
       rack
+    omniauth-gds (3.0.0)
+      omniauth-oauth2 (~> 1.0)
     omniauth-github (1.1.1)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
@@ -235,6 +237,7 @@ GEM
       rest-client (~> 1.6.0)
     pjax_rails (0.3.4)
       jquery-rails
+    plek (1.7.0)
     polyglot (0.3.3)
     premailer (1.7.3)
       css_parser (>= 1.1.9)
@@ -404,10 +407,12 @@ DEPENDENCIES
   mongoid-rspec
   mongoid_rails_migrations
   octokit (~> 1.18)
+  omniauth-gds (= 3.0.0)
   omniauth-github
   oruen_redmine_client
   pivotal-tracker
   pjax_rails
+  plek (= 1.7.0)
   pry-rails
   puma
   quiet_assets

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -30,6 +30,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def gds
     auth = env["omniauth.auth"]
     if user = User.find_for_gds_oauth(auth)
+      user.clear_remotely_signed_out!
       flash[:success] = I18n.t "devise.omniauth_callbacks.success", :kind => "GDS Signon"
       sign_in_and_redirect user, :event => :authentication
     else

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -27,6 +27,16 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def gds
+    auth = env["omniauth.auth"]
+    if user = User.find_for_gds_oauth(auth)
+      flash[:success] = I18n.t "devise.omniauth_callbacks.success", :kind => "GDS Signon"
+      sign_in_and_redirect user, :event => :authentication
+    else
+      render :status => 403, :text => I18n.t("devise.omniauth_callbacks.failure", :kind => "GDS Signon", :reason => "Computer says no")
+    end
+  end
+
   private
 
   def update_user_with_github_attributes(user, login, token)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,12 @@
+class Users::SessionsController < Devise::SessionsController
+
+  def new
+    redirect_to user_omniauth_authorize_path(:gds)
+  end
+
+  private
+
+  def after_sign_out_path_for(resource_name)
+    GDS::SSO::Config.oauth_root_url + "/users/sign_out"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User
   ### GDS SSO
   field :uid, :type => String
   field :remotely_signed_out, :type => Boolean, :default => false
+  index :uid => 1
 
   before_save :ensure_authentication_token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User
 
   ### GDS SSO
   field :uid, :type => String
+  field :remotely_signed_out, :type => Boolean, :default => false
 
   before_save :ensure_authentication_token
 
@@ -90,6 +91,18 @@ class User
 
   def self.token_authentication_key
     :auth_token
+  end
+
+  def active_for_authentication?
+    super && ! remotely_signed_out
+  end
+
+  def set_remotely_signed_out!
+    self.update_attribute(:remotely_signed_out, true) unless self.remotely_signed_out
+  end
+
+  def clear_remotely_signed_out!
+    self.update_attribute(:remotely_signed_out, false) if self.remotely_signed_out
   end
 
   def self.find_for_gds_oauth(auth_hash)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,9 @@ class User
 
   index :authentication_token => 1
 
+  ### GDS SSO
+  field :uid, :type => String
+
   before_save :ensure_authentication_token
 
   validates_presence_of :name
@@ -61,7 +64,7 @@ class User
   end
 
   def password_required?
-    github_login.present? ? false : super
+    (github_login.present? or uid.present?) ? false : super
   end
 
   def github_account?
@@ -87,6 +90,19 @@ class User
 
   def self.token_authentication_key
     :auth_token
+  end
+
+  def self.find_for_gds_oauth(auth_hash)
+    return false unless auth_hash.has_key?('info') and auth_hash.has_key?('extra') and auth_hash['extra'].has_key?('user')
+
+    permissions = auth_hash['extra']['user']['permissions'] || []
+    return false unless permissions.include?('signin')
+
+    user = self.where(:uid => auth_hash['uid']).first_or_initialize
+    user.admin = permissions.include?("admin")
+    user.name = auth_hash['info']['name']
+    user.email = auth_hash['info']['email']
+    user.save and user
   end
 
   private

--- a/config/initializers/_gds_sso.rb
+++ b/config/initializers/_gds_sso.rb
@@ -1,6 +1,8 @@
 # This file is overwritten on deploy
 
 # This file name has a leading _ to ensure it's loaded before devise_overrides.rb
+# Rails guarantees to load these files in alphabetical order. See
+# http://guides.rubyonrails.org/configuring.html#using-initializer-files
 
 require 'ostruct'
 

--- a/config/initializers/_gds_sso.rb
+++ b/config/initializers/_gds_sso.rb
@@ -1,0 +1,15 @@
+# This file is overwritten on deploy
+
+# This file name has a leading _ to ensure it's loaded before devise_overrides.rb
+
+require 'ostruct'
+
+module GDS
+  module SSO
+    Config = OpenStruct.new({
+      :oauth_id       => "abcdefghjasndjkasnderrbit",
+      :oauth_secret   => "secret",
+      :oauth_root_url => Plek.new.find('signon'),
+    })
+  end
+end

--- a/config/initializers/devise_overrides.rb
+++ b/config/initializers/devise_overrides.rb
@@ -1,0 +1,10 @@
+Devise.setup do |config|
+  config.omniauth :gds,
+    GDS::SSO::Config.oauth_id,
+    GDS::SSO::Config.oauth_secret,
+    :client_options => {
+      :site => GDS::SSO::Config.oauth_root_url,
+      :authorize_url => "/oauth/authorize",
+      :token_url => "/oauth/access_token",
+    }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Errbit::Application.routes.draw do
 
-  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
+  devise_for :users, :controllers => { :sessions => "users/sessions", :omniauth_callbacks => "users/omniauth_callbacks" }
 
   # Hoptoad Notifier Routes
   match '/notifier_api/v2/notices' => 'notices#create', via: [:get, :post]

--- a/spec/acceptance/acceptance_helper.rb
+++ b/spec/acceptance/acceptance_helper.rb
@@ -18,9 +18,15 @@ def mock_auth(user = "test_user", token = "abcdef")
   )
 end
 
+def mock_gds_sso_auth(uid, details = {})
+  OmniAuth.config.mock_auth[:gds] = gds_omniauth_hash_stub(uid, details)
+end
+
 def log_in(user)
+  user.update_attributes!(:uid => Devise.friendly_token) if user.uid.blank?
+  mock_gds_sso_auth(user.uid,
+                   :email => user.email,
+                   :permissions => user.admin? ? %w(signin admin) : %w(signin)
+                   )
   visit '/'
-  fill_in :user_email, :with => user.email
-  fill_in :user_password, :with => 'password'
-  click_on I18n.t('devise.sessions.new.sign_in')
 end

--- a/spec/acceptance/sign_in_with_gds_sso_spec.rb
+++ b/spec/acceptance/sign_in_with_gds_sso_spec.rb
@@ -2,10 +2,6 @@ require 'acceptance/acceptance_helper'
 
 feature 'Sign in with GDS SSO' do
 
-  def mock_gds_sso_auth(uid, details = {})
-    OmniAuth.config.mock_auth[:gds] = gds_omniauth_hash_stub(uid, details)
-  end
-
   context "no existing local user" do
     scenario 'logging in as a user with signin permission' do
       mock_gds_sso_auth('1234')

--- a/spec/acceptance/sign_in_with_gds_sso_spec.rb
+++ b/spec/acceptance/sign_in_with_gds_sso_spec.rb
@@ -9,7 +9,7 @@ feature 'Sign in with GDS SSO' do
   context "no existing local user" do
     scenario 'logging in as a user with signin permission' do
       mock_gds_sso_auth('1234')
-      visit '/users/auth/gds'
+      visit '/'
 
       expect(page).to have_content(I18n.t("devise.omniauth_callbacks.success", :kind => 'GDS Signon'))
 
@@ -22,7 +22,7 @@ feature 'Sign in with GDS SSO' do
 
     scenario 'logging in as a signon with admin permission sets local admin flag' do
       mock_gds_sso_auth('1234', :permissions => %w(signin admin))
-      visit '/users/auth/gds'
+      visit '/'
 
       expect(page).to have_content(I18n.t("devise.omniauth_callbacks.success", :kind => 'GDS Signon'))
 
@@ -33,7 +33,7 @@ feature 'Sign in with GDS SSO' do
 
     scenario 'attempting to log in as a user without signin permission' do
       mock_gds_sso_auth('1234', :permissions => [])
-      visit '/users/auth/gds'
+      visit '/'
 
       expect(page).to have_content(I18n.t("devise.omniauth_callbacks.failure", :kind => 'GDS Signon', :reason => "Computer says no"))
 

--- a/spec/acceptance/sign_in_with_gds_sso_spec.rb
+++ b/spec/acceptance/sign_in_with_gds_sso_spec.rb
@@ -1,0 +1,44 @@
+require 'acceptance/acceptance_helper'
+
+feature 'Sign in with GDS SSO' do
+
+  def mock_gds_sso_auth(uid, details = {})
+    OmniAuth.config.mock_auth[:gds] = gds_omniauth_hash_stub(uid, details)
+  end
+
+  context "no existing local user" do
+    scenario 'logging in as a user with signin permission' do
+      mock_gds_sso_auth('1234')
+      visit '/users/auth/gds'
+
+      expect(page).to have_content(I18n.t("devise.omniauth_callbacks.success", :kind => 'GDS Signon'))
+
+      u = User.where(:uid => '1234').first
+      expect(u).to be
+      expect(u.name).to eq("Test User")
+      expect(u.email).to eq("test@example.com")
+      expect(u.admin).to be_false
+    end
+
+    scenario 'logging in as a signon with admin permission sets local admin flag' do
+      mock_gds_sso_auth('1234', :permissions => %w(signin admin))
+      visit '/users/auth/gds'
+
+      expect(page).to have_content(I18n.t("devise.omniauth_callbacks.success", :kind => 'GDS Signon'))
+
+      u = User.where(:uid => '1234').first
+      expect(u).to be
+      expect(u.admin).to be_true
+    end
+
+    scenario 'attempting to log in as a user without signin permission' do
+      mock_gds_sso_auth('1234', :permissions => [])
+      visit '/users/auth/gds'
+
+      expect(page).to have_content(I18n.t("devise.omniauth_callbacks.failure", :kind => 'GDS Signon', :reason => "Computer says no"))
+
+      u = User.where(:uid => '1234').first
+      expect(u).to be_nil
+    end
+  end
+end

--- a/spec/acceptance/sign_in_with_github_spec.rb
+++ b/spec/acceptance/sign_in_with_github_spec.rb
@@ -1,6 +1,6 @@
 require 'acceptance/acceptance_helper'
 
-feature 'Sign in with GitHub' do
+feature 'Sign in with GitHub', :pending => "No longer applicable due to GDS SSO" do
 
   background do
     Errbit::Config.stub(:github_authentication) { true }

--- a/spec/controllers/devise_sessions_controller_spec.rb
+++ b/spec/controllers/devise_sessions_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Devise::SessionsController do
+describe Devise::SessionsController, :pending => "No longer applicable due to GDS SSO" do
   render_views
 
   describe "POST /users/sign_in" do

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -57,7 +57,7 @@ describe Users::OmniauthCallbacksController do
 
     context "with a valid user" do
       before :each do
-        @mock_user = mock_model(User)
+        @mock_user = mock_model(User, :clear_remotely_signed_out! => nil)
         User.stub(:find_for_gds_oauth).and_return(@mock_user)
 
         @controller.stub(:sign_in_and_redirect)
@@ -66,6 +66,11 @@ describe Users::OmniauthCallbacksController do
 
       it "should create/update a user from the details" do
         User.should_receive(:find_for_gds_oauth).with(@stub_omniauth_hash).and_return(@mock_user)
+        get :gds
+      end
+
+      it "should clear remotely_signed_out flag on the user" do
+        @mock_user.should_receive(:clear_remotely_signed_out!)
         get :gds
       end
 

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -39,4 +39,53 @@ describe Users::OmniauthCallbacksController do
   end
 
   # See spec/acceptance/sign_in_with_github_spec.rb for 'Signing in with github' integration tests.
+
+  def stub_env_for_gds_omniauth(uid, details = {})
+    # This a Devise specific thing for functional tests. See https://github.com/plataformatec/devise/issues/closed#issue/608
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    @stub_omniauth_hash = gds_omniauth_hash_stub(uid, details)
+    env = {
+      "omniauth.auth" => @stub_omniauth_hash,
+    }
+    @controller.stub(:env).and_return(env)
+  end
+
+  context 'Callback from GDS SSO' do
+    before :each do
+      stub_env_for_gds_omniauth('1234')
+    end
+
+    context "with a valid user" do
+      before :each do
+        @mock_user = mock_model(User)
+        User.stub(:find_for_gds_oauth).and_return(@mock_user)
+
+        @controller.stub(:sign_in_and_redirect)
+        @controller.stub(:render) # prevent missing template errors due to stubbing sign_in_and_redirect etc.
+      end
+
+      it "should create/update a user from the details" do
+        User.should_receive(:find_for_gds_oauth).with(@stub_omniauth_hash).and_return(@mock_user)
+        get :gds
+      end
+
+      it "should sign in and redirect the user" do
+        @controller.should_receive(:sign_in_and_redirect).with(@mock_user, :event => :authentication)
+        get :gds
+      end
+    end
+
+    context "with an invalid user" do
+      before :each do
+        User.stub(:find_for_gds_oauth).and_return(nil)
+      end
+
+      it "should display an error message to the user" do
+        get :gds
+
+        expect(response.status).to eq(403)
+        expect(response.body).to match("Computer says no")
+      end
+    end
+  end
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Users::SessionsController do
+
+  before :each do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  describe "GET new" do
+    it "should redirect to gds oauth" do
+      get :new
+
+      expect(response).to redirect_to("/users/auth/gds")
+    end
+  end
+
+  describe "DELETE destroy" do
+    it "should redirect to signon to continue logout there" do
+      delete :destroy
+
+      expect(response).to redirect_to("#{GDS::SSO::Config.oauth_root_url}/users/sign_out")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,5 +71,86 @@ describe User do
     end
   end
 
+  context "GDS SSO additions" do
+    describe "find_for_gds_oauth" do
+      before :each do
+        @oauth_hash = gds_omniauth_hash_stub('123456', :name => 'Testy McTest', :email => 'test@example.com')
+      end
+
+      it "should return falseish if given a hash missing the necessary details" do
+        expect(User.find_for_gds_oauth({:foo => :bar})).to be_false
+        expect(User.find_for_gds_oauth({'info' => {}, 'extra' => {'user' => {}}})).to be_false
+      end
+
+      it "should return falseish if the signon user doesn't have signin permission" do
+        @oauth_hash['extra']['user']['permissions'] = %w(something)
+        expect(User.find_for_gds_oauth(@oauth_hash)).to be_false
+      end
+
+      context "without an existing user" do
+        it "should create a user" do
+          expect {
+            User.find_for_gds_oauth(@oauth_hash)
+          }.to change { User.count }.by(1)
+        end
+
+        it "should populate the user details" do
+          u = User.find_for_gds_oauth(@oauth_hash)
+
+          expect(u).to be_persisted
+          expect(u.uid).to eq('123456')
+          expect(u.name).to eq('Testy McTest')
+          expect(u.email).to eq('test@example.com')
+        end
+
+        it "should set the admin flag" do
+          u = User.find_for_gds_oauth(@oauth_hash)
+          expect(u).not_to be_admin
+
+          @oauth_hash['extra']['user']['permissions'] = %w(signin admin)
+          u = User.find_for_gds_oauth(@oauth_hash)
+          expect(u).to be_admin
+        end
+
+        it "should return a falseish value if the user can't be created" do
+          @oauth_hash['info']['email'] = "not an email address"
+
+          expect(User.find_for_gds_oauth(@oauth_hash)).to be_false
+        end
+      end
+
+      context "with an existing user" do
+        before :each do
+          @user = Fabricate(:user, :uid => '123456')
+        end
+
+        it "should update the user details" do
+          u = User.find_for_gds_oauth(@oauth_hash)
+
+          @user.reload
+          expect(@user.name).to eq('Testy McTest')
+          expect(@user.email).to eq('test@example.com')
+        end
+
+        it "should update the admin flag" do
+          @user.update_attributes!(:admin => true)
+
+          User.find_for_gds_oauth(@oauth_hash)
+          expect(@user.reload).not_to be_admin
+
+          @oauth_hash['extra']['user']['permissions'] = %w(signin admin)
+          User.find_for_gds_oauth(@oauth_hash)
+          expect(@user.reload).to be_admin
+        end
+
+        it "should return falseish if the user can't be updated" do
+          @oauth_hash['info']['email'] = "not an email address"
+
+          expect(User.find_for_gds_oauth(@oauth_hash)).to be_false
+        end
+      end
+
+    end
+  end
 end
 

--- a/spec/support/gds_auth_stubs.rb
+++ b/spec/support/gds_auth_stubs.rb
@@ -1,0 +1,31 @@
+module GdsAuthStubs
+  def gds_omniauth_hash_stub(uid, details = {})
+    details = {
+      :name => "Test User",
+      :email => "test@example.com",
+      :permissions => ['signin']
+    }.merge(details)
+
+    Hashie::Mash.new(
+      'provider' => 'gds',
+      'uid' => uid,
+      'info' => {
+        'name' => details[:name],
+        'email' => details[:email],
+      },
+      'extra' => {
+        "user" => {
+          "uid" => uid,
+          "name" => details[:name],
+          "email" => details[:email],
+          "permissions" => details[:permissions],
+        },
+      },
+      'credentials' => {
+        'token' => Devise.friendly_token,
+      }
+    )
+  end
+end
+
+RSpec.configuration.include GdsAuthStubs


### PR DESCRIPTION
This is the first piece of this work.  This enables logging in via signon, and setting/clearing the admin flag based on the role in signon.

Still to do:
- Signon remote update callback endpoints
- Removing parts of the UI that no longer apply.
