### PR TITLE
Remove non-applicable bits of User admin UI

### DIFF
--- a/app/views/users/_fields.html.haml
+++ b/app/views/users/_fields.html.haml
@@ -2,7 +2,7 @@
 
 .required
   = f.label :name
-  = f.text_field :name
+  = f.text_field :name, :disabled => true
 
 - if Errbit::Config.user_has_username
   .required
@@ -11,7 +11,7 @@
 
 .required
   = f.label :email
-  = f.text_field :email
+  = f.text_field :email, :disabled => true
 
 - if Errbit::Config.github_authentication
   = f.label :github_login
@@ -25,16 +25,8 @@
   = f.label :time_zone
   = f.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones
 
-.required
-  = f.label :password
-  = f.password_field :password, :autocomplete => "off"
-
-.required
-  = f.label :password_confirmation
-  = f.password_field :password_confirmation
-
 - if current_user.admin?
   .checkbox
-    = f.check_box :admin
+    = f.check_box :admin, :disabled => true
     = f.label :admin, 'Admin?'
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,6 +1,4 @@
 - content_for :title, 'Users'
-- content_for :action_bar do
-  %span= link_to('Add a New User', new_user_path, :class => 'add')
 
 %table.users
   %thead

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,7 +7,6 @@
 
 - content_for :action_bar do
   = render 'shared/link_github_account'
-  %span= link_to('Add a New User', new_user_path, :class => 'add')
   = link_to 'edit', edit_user_path(user), :class => 'button'
   = link_to 'destroy', user_path(user), :method => :delete,
     :data => { :confirm => t('users.confirm_delete') }, :class => 'delete button'


### PR DESCRIPTION
- Removed "Add user" buttons as users are added via signon
- Disabled name and email fields as these come from signon
- Disabled Admin? tickbox, as this is set via a signon role.
