### PR TITLE
Disable integrations with issue_trackers etc.

### DIFF
--- a/app/views/apps/_fields.html.haml
+++ b/app/views/apps/_fields.html.haml
@@ -63,6 +63,6 @@
   = f.check_box :resolve_errs_on_deploy
   = f.label :resolve_errs_on_deploy, 'Resolve errs on deploy'
 
-= render "issue_tracker_fields", :f => f
-= render "service_notification_fields", :f => f
+-#= render "issue_tracker_fields", :f => f
+-#= render "service_notification_fields", :f => f
 


### PR DESCRIPTION
Since the point os using errbit is to not have this data on 3rd-party servers, it seems sensibel to disable integrations that would forward it there.

Note: this is simply disabled at a view-level.  This should be fine for our uses.
