### PR TITLE
Increase session timeout.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -137,7 +137,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 8.hours
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false

--- a/spec/acceptance/auth_with_gds_sso_spec.rb
+++ b/spec/acceptance/auth_with_gds_sso_spec.rb
@@ -83,7 +83,7 @@ feature 'Authentication with GDS SSO' do
       visit '/'
       expect(page).to have_content(I18n.t("devise.omniauth_callbacks.success", :kind => 'GDS Signon'))
 
-      Timecop.travel(32.minutes.from_now)
+      Timecop.travel((8.hours + 2.minutes).from_now)
 
       visit '/problems'
       # The flash message indicates we've done the oauth dance again


### PR DESCRIPTION
The default 30 mins is quite agressive for this app.
