### PR TITLE
Remove aws-ses gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,8 +78,6 @@ gem 'omniauth-gds', '3.0.0'
 gem 'plek', '1.7.0'
 gem 'warden-oauth2', '0.0.1'
 
-gem 'aws-ses'
-
 gem 'logstasher', '0.4.8'
 #### End GDS additions ####
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,6 @@ GEM
       json
     arel (3.0.3)
     atomic (1.1.14)
-    aws-ses (0.5.0)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     bcrypt-ruby (3.1.2)
     better_errors (1.0.1)
       coderay (>= 1.0.0)
@@ -368,7 +363,6 @@ GEM
     webmock (1.15.0)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
-    xml-simple (1.1.2)
     xmpp4r (0.5.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -382,7 +376,6 @@ DEPENDENCIES
   actionmailer_inline_css
   actionpack (~> 3.2.17)
   airbrake
-  aws-ses
   better_errors
   binding_of_caller
   bitbucket_rest_api


### PR DESCRIPTION
Since https://github.gds/gds/alphagov-deployment/commit/b9bc59ac we're
using SMTP to talk to SES, and therefore no longer need this gem.
