### PR TITLE
Add query filter to applications index

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -8,7 +8,11 @@ class AppsController < ApplicationController
   respond_to :html
 
   expose(:app_scope) {
-    App
+    if !!params[:apps]
+      App.in(name: params[:apps])
+    else
+      App
+    end
   }
 
   expose(:apps) {

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -29,6 +29,10 @@ describe AppsController do
   let(:problem) do
     Fabricate(:problem, :app => app)
   end
+  let(:old_problem) do
+    Fabricate(:problem, :app => watched_app1,
+              :first_notice_at => Date.today - 3)
+  end
   let(:problem_resolved) { Fabricate(:problem_resolved, :app => app) }
 
   describe "GET /apps" do
@@ -50,16 +54,35 @@ describe AppsController do
       end
     end
 
-    context 'when app names are specified in params' do
-      it 'finds specified apps ordered by name' do
-        sign_in admin
-        watched_app1 && watched_app2 && unwatched_app
-        get :index, apps: [watched_app1.name, unwatched_app.name]
-        expect(controller.apps.entries).to eq [watched_app1, unwatched_app]
+    context 'when filtering apps' do
+      context 'by app name' do
+        it 'finds specified apps ordered by name' do
+          sign_in admin
+          watched_app1 && watched_app2 && unwatched_app
+          get :index, apps: [watched_app1.name, unwatched_app.name]
+          expect(controller.apps.entries).to eq [watched_app1, unwatched_app]
+        end
+      end
+
+      context 'by active problem date range' do
+        it 'finds specified apps ordered by name' do
+          sign_in admin
+          watched_app1 && watched_app2 && unwatched_app && problem && old_problem
+          get :index, from: Date.yesterday
+          expect(controller.apps.entries).to eq [unwatched_app]
+        end
+      end
+
+      context 'by active problems' do
+        it 'finds specified apps ordered by name' do
+          sign_in admin
+          watched_app1 && watched_app2 && unwatched_app && problem && old_problem
+          get :index, errors: 'true'
+          expect(controller.apps.entries).to eq [watched_app1, unwatched_app]
+        end
       end
     end
   end
-
 
   describe "GET /apps/:id" do
     context 'logged in as an admin' do

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -49,7 +49,17 @@ describe AppsController do
         expect(controller.apps.entries).to eq App.asc('name').entries
       end
     end
+
+    context 'when app names are specified in params' do
+      it 'finds specified apps ordered by name' do
+        sign_in admin
+        watched_app1 && watched_app2 && unwatched_app
+        get :index, apps: [watched_app1.name, unwatched_app.name]
+        expect(controller.apps.entries).to eq [watched_app1, unwatched_app]
+      end
+    end
   end
+
 
   describe "GET /apps/:id" do
     context 'logged in as an admin' do


### PR DESCRIPTION
The list of applications appearing in the apps/index view (the root view
for errbit) can be filtered using:
- App name eg `/apps?apps[]=Imminence&apps[]=Publisher`
- First notice date (when the first of a series of errors was thrown) eg `/apps?from=2014-11-01`
- Applications with active errors eg `/apps?errors=true`

https://www.agileplannerapp.com/boards/173808/cards/8007
