### PR TITLE
Don't require test-unit because it triggers autorun

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,8 @@ group :test do
   gem 'database_cleaner'
   gem 'email_spec'
   gem 'timecop'
-  gem 'test-unit', require: 'test/unit'
+  ## GDS change: don't require test-unit as it triggers auto-running which breaks CI
+  gem 'test-unit', require: false
   gem 'coveralls', require: false
   #### GDS additions ####
   gem 'webmock'


### PR DESCRIPTION
Errbit doesn't have any test-unit tests. Requiring test-unit triggers a
test-unit autorun which breaks CI. The problem is similar to the one
described here:

http://stackoverflow.com/questions/1899009/why-are-tests-running-in-production-mode-and-causing-my-script-runners-to-fail
