### PR TITLE
Upgrade Rails to 4.1.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-RAILS_VERSION = '~> 4.1.11'
+RAILS_VERSION = '~> 4.1.14.1'
 
 send :ruby, ENV['GEMFILE_RUBY_VERSION'] if ENV['GEMFILE_RUBY_VERSION']
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,31 +15,31 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.1.11)
-      actionpack (= 4.1.11)
-      actionview (= 4.1.11)
+    actionmailer (4.1.14.1)
+      actionpack (= 4.1.14.1)
+      actionview (= 4.1.14.1)
       mail (~> 2.5, >= 2.5.4)
     actionmailer_inline_css (1.5.3)
       actionmailer (>= 3.0.0)
       nokogiri (>= 1.4.4)
       premailer (>= 1.7.1)
-    actionpack (4.1.11)
-      actionview (= 4.1.11)
-      activesupport (= 4.1.11)
+    actionpack (4.1.14.1)
+      actionview (= 4.1.14.1)
+      activesupport (= 4.1.14.1)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.11)
-      activesupport (= 4.1.11)
+    actionview (4.1.14.1)
+      activesupport (= 4.1.14.1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-    activemodel (4.1.11)
-      activesupport (= 4.1.11)
+    activemodel (4.1.14.1)
+      activesupport (= 4.1.14.1)
       builder (~> 3.1)
-    activerecord (4.1.11)
-      activemodel (= 4.1.11)
-      activesupport (= 4.1.11)
+    activerecord (4.1.14.1)
+      activemodel (= 4.1.14.1)
+      activesupport (= 4.1.14.1)
       arel (~> 5.0.0)
-    activesupport (4.1.11)
+    activesupport (4.1.14.1)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -270,15 +270,15 @@ GEM
     rack-ssl-enforcer (0.2.6)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.1.11)
-      actionmailer (= 4.1.11)
-      actionpack (= 4.1.11)
-      actionview (= 4.1.11)
-      activemodel (= 4.1.11)
-      activerecord (= 4.1.11)
-      activesupport (= 4.1.11)
+    rails (4.1.14.1)
+      actionmailer (= 4.1.14.1)
+      actionpack (= 4.1.14.1)
+      actionview (= 4.1.14.1)
+      activemodel (= 4.1.14.1)
+      activerecord (= 4.1.14.1)
+      activesupport (= 4.1.14.1)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.1.11)
+      railties (= 4.1.14.1)
       sprockets-rails (~> 2.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
@@ -287,9 +287,9 @@ GEM
       rails (> 3.1)
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.3)
-    railties (4.1.11)
-      actionpack (= 4.1.11)
-      activesupport (= 4.1.11)
+    railties (4.1.14.1)
+      actionpack (= 4.1.14.1)
+      activesupport (= 4.1.14.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
@@ -404,9 +404,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionmailer (~> 4.1.11)
+  actionmailer (~> 4.1.14.1)
   actionmailer_inline_css
-  actionpack (~> 4.1.11)
+  actionpack (~> 4.1.14.1)
   airbrake
   better_errors
   binding_of_caller
@@ -456,7 +456,7 @@ DEPENDENCIES
   rack-ssl-enforcer
   rails_12factor
   rails_autolink
-  railties (~> 4.1.11)
+  railties (~> 4.1.14.1)
   ri_cal
   rspec
   rspec-activemodel-mocks


### PR DESCRIPTION
**Story: https://trello.com/c/deUxEIuv/61-errbit**

To mitigate potential security vulnerabilities:
http://weblog.rubyonrails.org/2016/1/25/Rails-5-0-0-beta1-1-4-2-5-1-4-1-14-1-3-2-22-1-and-rails-html-sanitizer-1-0-3-have-been-released/

I have not checked if the app is vulnerable to these issues.

The `govuk_security_audit` gem reports several other possible issues
with Gems used by this app, which this pull request does not address. We
can address those separately.

I was unable to upgrade simply by changing `RAILS_VERSION` and running
`bundle install`, apparently due to cyclical dependencies. Also,
deleting the `Gemfile.lock` was not an option because many of the gems
are not pinned in the `Gemfile`, meaning I'd inadvertently upgrade
unrelated gems. So I ran:

```
sed -i '' 's/4.1.11/4.1.14.1/g' Gemfile.lock
```

...which allowed `bundle install` to run successfully.
