### PR TITLE
Add monkey patch to workaround rspec-rails bug

### DIFF
--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -1,3 +1,14 @@
+# FIXME: This is a monkey patch to workaround an issue in rspec-rails:
+#
+#   NoMethodError:
+#     undefined method `cache' for nil:NilClass
+#
+# See: https://github.com/rspec/rspec-rails/issues/1532#issuecomment-174679485
+#
+RSpec::Rails::ViewRendering::EmptyTemplatePathSetDecorator.class_eval do  
+  alias_method :find_all_anywhere, :find_all
+end
+
 describe ProblemsController, type: 'controller' do
   it_requires_authentication :for => {
     :index => :get, :show => :get, :resolve => :put, :search => :get


### PR DESCRIPTION
**Story: https://trello.com/b/UselbkvT/rails-rails-html-sanitizer-upgrade-deploys**

This monkey patch is required following the upgrade to Rails 4.1.14.1 to
apply security updates in 329e3b2b. Without it, the tests fail.

See the GitHub issue for more details:
https://github.com/rspec/rspec-rails/issues/1532#issuecomment-174679485
